### PR TITLE
Migrate and modify Python information

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build the book
         shell: bash -l {0}
-        run: jupyter book build docs
+        run: jupyter book build -W docs
     
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -22,6 +22,12 @@ parts:
     - file: python-linting
     - file: python-pre-commit
 
+  - caption: Github
+    chapters:
+    - file: gh-workflows
+    - file: gh-citable
+    - file: gh-issues
+  
   - caption: Contact
     chapters:
     - file: contact

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -14,6 +14,14 @@ parts:
     chapters:
     - file: packages
 
+  - caption: Python
+    chapters:
+    - file: python-packaging
+    - file: python-testing
+    - file: python-coverage
+    - file: python-linting
+    - file: python-pre-commit
+
   - caption: Contact
     chapters:
     - file: contact

--- a/docs/gh-citable.md
+++ b/docs/gh-citable.md
@@ -1,0 +1,16 @@
+# Make a repository citable
+The easiest way to make your repository citable is to add a `CITATION.cff` file to the repository, as it is supported by both
+[Zenodo's](https://zenodo.org/) and it's [Github integration](https://docs.github.com/en/repositories/archiving-a-github-repository/referencing-and-citing-content) and [Github](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) itself.
+
+A simple `CITATION.cff` file can look as suggested below:
+```cff
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Dokken"
+  given-names: "Jørgen S."
+  orcid: "https://orcid.org/0000-0001-6489-8858"
+title: "Scientific Computing - A webpage for reproducible research"
+version: x.y.z
+date-released: YYYY-MM-DD
+```

--- a/docs/gh-citable.md
+++ b/docs/gh-citable.md
@@ -3,7 +3,7 @@ The easiest way to make your repository citable is to add a `CITATION.cff` file 
 [Zenodo's](https://zenodo.org/) and it's [Github integration](https://docs.github.com/en/repositories/archiving-a-github-repository/referencing-and-citing-content) and [Github](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) itself.
 
 A simple `CITATION.cff` file can look as suggested below:
-```cff
+```yaml
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 authors:

--- a/docs/gh-issues.md
+++ b/docs/gh-issues.md
@@ -1,0 +1,14 @@
+# Issue template
+Issue templates are an easy way of suggesting a structure for users that want new features, report bugs etc. to your code.
+
+These have for instance been used in this web-page to report missing [Research papers](https://github.com/scientificcomputing/scientificcomputing.github.io/issues/new?assignees=&labels=new-repo&template=repository.yml&title=%5BAdd+repo%5D%3A+) and missing [Software packages](https://github.com/scientificcomputing/scientificcomputing.github.io/issues/new?assignees=&labels=new-package&template=package.yml&title=%5BAdd+package%5D%3A+)
+
+The templates are [YAML](https://yaml.org/)-files that should be added to the `.github` folder as shown below:
+```
+└── .github
+    └── ISSUE_TEMPLATE
+        ├── report_bug.yml
+        └── add_package.yml
+```
+
+See <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository> for more information about supported syntax.

--- a/docs/gh-workflows.md
+++ b/docs/gh-workflows.md
@@ -1,0 +1,32 @@
+Github has loads of features that can improve the quality of your code.
+We will cover some of these features in this section.
+
+
+# Workflows
+A Github workflow is a way of creating executable jobs that is executed either when commiting to a branch, creating a pull request or creating a release/tag.
+They are specified in [YAML](https://yaml.org/)-formatting.
+
+More information about workflows can be found in the [Github Documentation](https://docs.github.com/en/actions/using-workflows/about-workflows)
+
+A workflow should be placed in the `.github` repository as shown below
+```
+└── .github
+    └── worflkows
+        ├── test_code.yml
+        └── publish_docs.yml
+```
+
+## Actions
+[Github Actions](https://github.com/features/actions) is a prebuilt set of instructions to make it easier to interact with Github.
+The actions officially maintained by Github can be found at: [GitHub/actions](https://github.com/actions)
+
+## Uploading artifacts
+As covered in the [Coverage report](../part1/coverage)-section, we use the [Upload artifact action](https://github.com/actions/upload-artifact#readme)
+
+(publishing-to-pages)=
+
+## Publishing to Pages
+There are several ways to publish a set of html files to Github Pages.
+One can either:
+1. __Official actions__: See [custom Github Actions to publish your site](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#creating-a-custom-github-actions-workflow-to-publish-your-site) for details
+2. __Unofficial action__: Preceeding Github's official actions [peaceiris/actions-gh-pages](https://github.com/marketplace/actions/github-pages-action) was a popular option

--- a/docs/gh-workflows.md
+++ b/docs/gh-workflows.md
@@ -21,7 +21,7 @@ A workflow should be placed in the `.github` repository as shown below
 The actions officially maintained by Github can be found at: [GitHub/actions](https://github.com/actions)
 
 ## Uploading artifacts
-As covered in the [Coverage report](../part1/coverage)-section, we use the [Upload artifact action](https://github.com/actions/upload-artifact#readme)
+As covered in the [Coverage report](./python-coverage)-section, we use the [Upload artifact action](https://github.com/actions/upload-artifact#readme)
 
 (publishing-to-pages)=
 

--- a/docs/python-coverage.md
+++ b/docs/python-coverage.md
@@ -1,0 +1,28 @@
+# Coverage reports
+
+When creating a Python package, it can be very useful to know what part of your code is covered by the tests.
+
+We recommend using [pytest-cov](https://pytest-cov.readthedocs.io/en/latest/) which extends the [pytest](./python-testing.md) suite with a coverage report of your package.
+
+We add to the `addopts` section of the `[tool.pytest.ini_options]` table of [pyproject.toml](content:pyproject):
+```toml
+addopts = [
+    # Other options
+    "--cov=mypackage",
+    "--cov-report=html",
+    "--cov-report=term-missing",
+    "-v"]
+```
+
+We use Github Actions to upload the coverage report as an artifact after executing the tests. We add the following step
+```yaml
+      - name: Run tests
+        run: python -m pytest
+
+      - name: Upload coverage report as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage-report
+          path: htmlcov
+          if-no-files-found: error
+```

--- a/docs/python-linting.md
+++ b/docs/python-linting.md
@@ -1,0 +1,62 @@
+# Formatting
+
+## Following the PEP8 style guide
+To ensure that your Python-code is well formatted, one can use tools such as [flake8](https://flake8.pycqa.org/en/latest/), which can be installed with
+```bash
+python -m pip install flake8
+```
+Flake8 checks the consistency (following the [PEP8 style guide](https://peps.python.org/pep-0008/)) of your code, using
+- Pyflake, with the following [checks](https://flake8.pycqa.org/en/latest/user/error-codes.html)
+- Pycodestyle, with the following [checks](https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes)
+
+Flake8 can be executed with
+```bash
+python -m flake8
+```
+Call
+```bash
+python -m flake8 --help
+```
+for listing the listing options
+
+We add a `.flake8` file in the project root with some additional configurations
+```
+[flake8]
+exclude = docs,venv
+max-line-length = 100
+```
+
+To ignore `flake8` formatting on certain lines, or ignore certain rules, see: [Ignoring Errors with Flake8](https://flake8.pycqa.org/en/3.1.1/user/ignoring-errors.html).
+
+## Code consistency
+Flake8 only checks the consistency of your code to a certain extent.
+Modern Python allows for [type hints](https://peps.python.org/pep-0484/) which means that you can specify the input and output type for functions.
+
+However, type-checking does not happen during run-time.
+We prefer using [mypy](http://mypy-lang.org/) to perform these checks.
+Mypy can be installed from [The Python Package Index](https://pypi.org/) (PYPI)
+```bash
+python -m pip install mypy
+```
+and be executed as
+```bash
+python -m mypy
+```
+We add the following options to [pyproject.toml](content:pyproject)
+```toml
+[tool.mypy]
+ignore_missing_imports = true
+# Folders to exclude
+exclude = [
+    "docs/",
+    "build/"
+]
+ # Folder to check with mypy
+files = [
+    "src",
+    "tests" # Does not show errors when importing untyped libraries
+]
+```
+where `ignore_missing_imports` is set to `True` to suppress all errors coming from third-party libraries that are untyped.
+
+To let `mypy` ignore single lines or whole files, see: [Locally silencing the checker](https://mypy.readthedocs.io/en/stable/common_issues.html#spurious-errors-and-locally-silencing-the-checker).

--- a/docs/python-packaging.md
+++ b/docs/python-packaging.md
@@ -15,7 +15,7 @@ We recommend using the source layout. See [this chapter](https://py-pkgs.org/04-
         └── functions.py
 ```
 ### `.git`
-The .git folder is covered in [Version control](./version_control.md)
+The .git folder is covered in Version control (FIXME: Add link)
 
 
 ### `README.md`

--- a/docs/python-packaging.md
+++ b/docs/python-packaging.md
@@ -15,7 +15,7 @@ We recommend using the source layout. See [this chapter](https://py-pkgs.org/04-
         └── functions.py
 ```
 ### `.git`
-The .git folder is covered in Version control (FIXME: Add link)
+The .git folder is covered in [Version control](./version_control)
 
 
 ### `README.md`

--- a/docs/python-packaging.md
+++ b/docs/python-packaging.md
@@ -1,0 +1,76 @@
+# Create an installable package
+
+In this section we will cover how to easily make an installable Python package.
+
+## Repository structure
+We recommend using the source layout. See [this chapter](https://py-pkgs.org/04-package-structure.html#the-source-layout) for justification. This means that from the root of your Github repository you should have a folder structure like
+```
+├── .git
+├── README.md
+├── LICENSE
+├── pyproject.toml
+└── src
+    └── name_of_package
+        ├── __init__.py
+        └── functions.py
+```
+### `.git`
+The .git folder is covered in [Version control](./version_control.md)
+
+
+### `README.md`
+This file should contain a description of your package. This could include installation instructions or simple use-cases. It is written in the [Markdown](https://www.markdownguide.org/).
+
+### `LICENSE`
+For other people to be able to use your software, it needs to have a license. For a list of available licenses see <https://spdx.org/licenses/>.
+
+(content:pyproject)=
+### `pyproject.toml`
+A [toml](https://toml.io/en/) (Tom's Obivous Minimal Language) file is a plain-text file, consisting of [tables](https://toml.io/en/v1.0.0#table)
+which are a selection of key-value pairs.
+
+An example is
+```toml
+[project]
+name = "catch_us"
+authors = [
+    {name = "Per Ulv", email = "per@acme.no"},
+    {name = "Bippe Stankelbein", email = "bippe@roadrunner.no"}
+    ]
+version = "x.y.z"
+requires-python = ">=3.8"
+
+# Short description
+description = "Meep Meep"
+
+# Path to README.md
+readme = "README.md"
+
+# Path to license file
+license = {file = "LICENSE"}
+
+# Direct dependencies
+dependencies = [
+    'acme',
+    'numpy'
+]
+```
+
+#### Optional dependencies
+The core functionality of a package (its classes and functions) might not depend on many other packages.
+
+However, to be able to test the code, check for consistency and create coverage reports, one might meed additional dependencies.
+
+One can therefore specify a second table in the `pyproject.toml` file, called
+[project.optional-depencies].
+This is treated as a sub-table of `project`.
+
+For instance, if you want to test your package with [pytest](https://docs.pytest.org/en/7.1.x/), you can add
+```toml
+[project.optional-dependencies]
+test = ["pytest"]
+```
+Then, when installing the package, you call `pip3 install .[test]` instead of `pip3 install .` to get the additional dependencies.
+
+#### Other tables
+For options related to coverage reports and code consistency, see the [Coverage](./python-coverage) and [Linting](./python-linting.md) section, respectively.

--- a/docs/python-pre-commit.md
+++ b/docs/python-pre-commit.md
@@ -1,0 +1,21 @@
+# Pre-commit hooks
+
+Using pre-commit hooks is a great way to make sure that the code you commit to the repo follows some common style. This way, you will not end up changing the style back and forth when collaborating with other people.
+
+The file `.pre-commit-config.yaml` in the root of the repo contains a set of default pre-commit hooks. You can find more hooks in the [pre-commit home page](https://pre-commit.com/hooks.html).
+
+To install the pre-commit hook you first need to install pre-commit
+```bash
+python -m pip install pre-commit
+```
+and then install the pre-commit hook
+```bash
+pre-commit install
+```
+The pre-commit hook will only run on the files you commit to the repo. To run the pre-commit hook on all the files in your repo, you can execute the command.
+```bash
+pre-commit run --all
+```
+
+## Running pre-commit in CI
+You can also run the pre-commit hooks as a part of your continuous integration. You can check out the [GitHub action](https://github.com/pre-commit/action), or you can set up at webhook using [pre-commit.ci](https://pre-commit.ci).

--- a/docs/python-testing.md
+++ b/docs/python-testing.md
@@ -1,0 +1,36 @@
+# Testing
+
+It is very important to have tests for verification of your code.
+There are several types of tests, see for instance [Atlassian](https://www.atlassian.com/continuous-delivery/software-testing/types-of-software-testing) for a summary.
+
+The most important types of tests are the _unit tests_, which tests the core functionality of your code.
+
+The most common testing suite for Python in [pytest](https://docs.pytest.org/en/latest/), which can be installed from the [Python Package Index](https://docs.pytest.org/en/latest/) (PYPI) using
+```bash
+python -m pip install pytest
+```
+
+You can run `pytest` as
+```bash
+python -m pytest
+```
+Pytest will then find all files with names like `test_*.py` and `*_test.py`, see: [Conventions for test discovery](https://docs.pytest.org/en/latest/explanation/goodpractices.html#test-discovery) for more information.
+
+We add the following information to [pyproject.toml](content:pyproject) under table header: `[project.optional-dependencies]`
+```toml
+[project.optional-dependencies]
+# Other entries
+# ....
+test = [
+   "pytest",
+]
+
+[tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+    # Other entries ....
+]
+```
+The last option is due to pytest's recommendation for new projects, see [Choosing an import mode](https://docs.pytest.org/en/latest/explanation/goodpractices.html#choosing-an-import-mode) for more information.
+
+For other inputs to `[tool.pytest.ini_options]` see: <https://docs.pytest.org/en/latest/reference/customize.html#pyproject-toml>


### PR DESCRIPTION
Documentation was originally at https://github.com/scientificcomputing/reproducibility.
Following #15, we should aim to keep all general documentation on one web page. 

Long-term goal is to make reproducibility a minimal example of how the structure for a Python-package should be. 

I've added new information regarding this layout in `docs/python-packaging.md`